### PR TITLE
Update dependabot label to "dependencies/github-actions"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
       time: "02:00"
       interval: "weekly"
     labels:
-      - "dev-tooling"
+      - "dependencies/github-actions"


### PR DESCRIPTION
Closes #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the label for GitHub Actions dependency updates in the Dependabot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->