### PR TITLE
Add npm updates label

### DIFF
--- a/.github/workflows/utility-update-labels.yml
+++ b/.github/workflows/utility-update-labels.yml
@@ -19,6 +19,7 @@ jobs:
           {"name": "dependencies", "color": "9AF807", "description": "Dependency Updates"},          
           {"name": "dependencies/dotnet-sdk", "color": "512BD4", "description": ".NET SDK Updates"},
           {"name": "dependencies/nuget", "color": "512BD4", "description": "NuGet Updates"},
+          {"name": "dependencies/npmjs", "color": "CB3837", "description": "npm updates"},
           {"name": "dependencies/containers", "color": "0DB7ED", "description": "Container Updates"},
           {"name": "dependencies/github-actions", "color": "333333", "description": "GitHub Actions Updates"},
           {"name": "maintenance", "color": "2E7D32", "description": "Upkeep and tech debt reduction"},


### PR DESCRIPTION
Closes #37

## Summary by Sourcery

CI:
- Add a "dependencies/npmjs" label with color CB3837 and description "npm updates" to the update-labels workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal GitHub workflow configuration for improved tracking and organization of package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->