### PR TITLE
Fix Reusable Workflow: dotnet package

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -13,8 +13,7 @@ on:
       dotnet-version:
         required: false
         type: string
-        default: |
-          9.0.x
+        default: 10.0.x
         description: .NET Version to use (can use multiple)
       # Project
       project:
@@ -45,6 +44,10 @@ on:
         type: boolean
         default: false
         description: Publish the package to NuGet.org Public Registry
+    secrets:
+      NUGET_ORG_KEY:
+        required: false
+        description: NuGet.org API Key
 
 jobs:
   # Build
@@ -86,7 +89,7 @@ jobs:
       # .NET Test Upload Test Results from Testing
       - name: .NET Test Upload
         if: inputs.test
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test
           path: |
@@ -96,7 +99,7 @@ jobs:
       # .NET Coverage Upload Results from Testing
       - name: .NET Coverage Upload
         if: inputs.test
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: |
@@ -104,26 +107,28 @@ jobs:
 
       # .NET Pack
       - name: .NET Pack
-        if: ${{ inputs.pack && github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: ${{ inputs.pack && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
         run: dotnet pack ${{ inputs.project }} --no-build --configuration Release --output packages/
 
       # .NET Upload NuGet Artifact
       - name: .NET Upload NuGet Artifact
-        uses: actions/upload-artifact@v5
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        uses: actions/upload-artifact@v7
+        if: ${{ github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name }}
         with:
           name: nuget
           path: packages/
+
   # .NET Test Reporting
   test-report:
     # .NET Test Report
     name: .NET Test Report
     runs-on: ubuntu-latest
+    if: always() && inputs.test
     needs: build
     steps:
       # .NET Test Download Artifact
       - name: .NET Test Download Artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: test
 
@@ -141,11 +146,12 @@ jobs:
     # .NET Coverage Report
     name: .NET Coverage Report
     runs-on: ubuntu-latest
+    if: inputs.test
     needs: build
     steps:
       # .NET Coverage Download Artifact
       - name: .NET Coverage Download Artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: coverage
 
@@ -175,11 +181,11 @@ jobs:
     name: GitHub Publish
     runs-on: ubuntu-latest
     needs: build
-    if: inputs.github-publish
+    if: ${{ inputs.github-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
     steps:
       # GitHub Download NuGet Artifact [for GitHub Repository]
       - name: GitHub Download NuGet Artifact [for GitHub Repository]
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: nuget
 
@@ -192,11 +198,11 @@ jobs:
     name: NuGet.org Publish
     runs-on: ubuntu-latest
     needs: build
-    if: inputs.nuget-publish && secrets.NUGET_ORG_KEY
+    if: ${{ inputs.nuget-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) && secrets.NUGET_ORG_KEY }}
     steps:
       # GitHub Download NuGet Artifact [for NuGet.org Repository]
       - name: GitHub Download NuGet Artifact [for NuGet.org Repository]
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: nuget
 


### PR DESCRIPTION
Closes #45

## Summary by Sourcery

Update the reusable .NET packaging workflow to use newer action versions, target .NET 10 by default, and tighten publish conditions for releases.

Bug Fixes:
- Correct release gating conditions for packing, GitHub publishing, and NuGet.org publishing to only run on tagged release events with a configured API key.

Enhancements:
- Bump upload-artifact and download-artifact actions to their latest major versions in build, test, coverage, and publish jobs.
- Add workflow input secret metadata for the NuGet.org API key to improve reuse and configuration clarity.
- Gate test reporting and coverage jobs on the test input to avoid unnecessary runs.

Build:
- Change the default .NET SDK version used by the workflow from 9.0.x to 10.0.x.