### PR TITLE
Remove NuGet secret in condition

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -9,6 +9,12 @@ on:
         type: boolean
         default: true
         description: Build a solution
+      # Configuration
+      configuration:
+        required: false
+        type: string
+        default: Release
+        description: Build Configuration (e.g. Release, Debug, etc...)
       # .NET Version to use
       dotnet-version:
         required: false
@@ -73,13 +79,14 @@ jobs:
 
       # .NET Build
       - name: .NET Build
-        run: dotnet build ${{ inputs.project }} --no-restore --configuration Release
+        run: dotnet build ${{ inputs.project }} --no-restore --configuration ${{ inputs.configuration }}
 
       # .NET Test
       - name: .NET Test
         if: inputs.test
         run: |
           dotnet test \
+            --configuration ${{ inputs.configuration }} \
             --no-restore \
             --no-build \
             --nologo \
@@ -110,7 +117,7 @@ jobs:
       # .NET Pack
       - name: .NET Pack
         if: ${{ inputs.pack && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
-        run: dotnet pack ${{ inputs.project }} --no-build --configuration Release --output packages/
+        run: dotnet pack ${{ inputs.project }} --no-build --configuration ${{ inputs.configuration }} --output packages/
 
       # .NET Upload NuGet Artifact
       - name: .NET Upload NuGet Artifact
@@ -184,6 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: ${{ inputs.github-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
+    continue-on-error: true
     steps:
       # GitHub Download NuGet Artifact [for GitHub Repository]
       - name: GitHub Download NuGet Artifact [for GitHub Repository]

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -80,6 +80,8 @@ jobs:
         if: inputs.test
         run: |
           dotnet test \
+            --no-restore \
+            --no-build \
             --nologo \
             --collect "XPlat Code Coverage" \
             --test-adapter-path . \
@@ -113,7 +115,7 @@ jobs:
       # .NET Upload NuGet Artifact
       - name: .NET Upload NuGet Artifact
         uses: actions/upload-artifact@v7
-        if: ${{ github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: ${{ inputs.pack && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
         with:
           name: nuget
           path: packages/
@@ -198,7 +200,7 @@ jobs:
     name: NuGet.org Publish
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ inputs.nuget-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) && secrets.NUGET_ORG_KEY }}
+    if: ${{ inputs.nuget-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
     steps:
       # GitHub Download NuGet Artifact [for NuGet.org Repository]
       - name: GitHub Download NuGet Artifact [for NuGet.org Repository]

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -191,7 +191,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: ${{ inputs.github-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
-    continue-on-error: true
     steps:
       # GitHub Download NuGet Artifact [for GitHub Repository]
       - name: GitHub Download NuGet Artifact [for GitHub Repository]
@@ -209,6 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: ${{ inputs.nuget-publish && (github.event_name == 'release' && github.ref_type == 'tag' || github.event.release.tag_name) }}
+    continue-on-error: true
     steps:
       # GitHub Download NuGet Artifact [for NuGet.org Repository]
       - name: GitHub Download NuGet Artifact [for NuGet.org Repository]


### PR DESCRIPTION
Closes #47

## Summary by Sourcery

Adjust .NET CI workflow conditions and test execution flags for package publishing and test runs.

Enhancements:
- Run dotnet tests without restore or build in the CI workflow when tests are enabled.
- Gate NuGet artifact upload on the pack input flag alongside release tagging conditions.
- Remove the explicit NuGet.org API key presence check from the NuGet.org publish job condition while keeping existing release tag checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow testing to skip unnecessary restore and build steps.
  * Refined conditions for NuGet package artifact publishing and job execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->